### PR TITLE
Pre-select language based on browser preferences as a fallback.

### DIFF
--- a/login_lang.php
+++ b/login_lang.php
@@ -57,6 +57,7 @@ class login_lang extends rcube_plugin
     $user_lang = rcube::get_user_language();    
     $current = isset($_SESSION['lang_selected']) ? $_SESSION['lang_selected'] : $rcmail->config->get('language');              
     $current = $current? $current : $rcmail->config->get('language_dropdown_selected');
+    $current = $current? $current : $user_lang;
     $current = $current? $current : 'en_US';
     $select = new html_select(array('id'=>"_language",'name'=>'_language','style'=>'width:100%;padding:3px;'));
     $select->add(array_values($list_lang),array_keys($list_lang));        


### PR DESCRIPTION
Hi,

I've made a small tweak for the selection to play nicely with lang auto detection. It might be your original intention as well as the $user_lang variable was unused in the original code? I kept in the last fallback to en_US, though I'm not sure if the code might ever reach that point.

Cheers,
Petr
