### PR TITLE
FIX: cannot install this plugin on PHP >=5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "~5.2.1",
+        "php": ">=5.3,<6.0",
         "roundcube/plugin-installer": "~0.1.2"
     },
     "extra": {


### PR DESCRIPTION
As of roundcubemail 1.0, PHP 5.3 is REQUIRED, and this plugin is working correctly with PHP 5.4 and 5.5.
